### PR TITLE
INREL-3436 saving articles

### DIFF
--- a/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.module
+++ b/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.module
@@ -110,6 +110,10 @@ function _burdastyle_thunder_admin_form_alter_helper(&$form, FormStateInterface 
 	if (getenv('AH_SITE_ENVIRONMENT') == 'travis') {
 		$form['#attached']['library'][] = 'burdastyle_thunder_admin/travis_fix';
 	}
+  // TODO: check, if still relevant
+  // Remove 'save and view amp page' buttons
+  unset($form['actions']['save_view_amp']);
+  unset($form['actions']['save_view_amp_with_warn']);
 }
 
 /**


### PR DESCRIPTION
This PR removes the "Save and view AMP page" buttons.
Since this module is used in every project, all projects can get this change with an update of this module.

To test this, please view https://github.com/BurdaMagazinOrg/instyle-web/pull/271

Next steps:
After merge, update projects