### PR TITLE
add warning for editors when switching between normal and edit plus mode INREL-4521

### DIFF
--- a/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.libraries.yml
+++ b/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.libraries.yml
@@ -18,3 +18,11 @@ ecommerce_slider_form:
     - core/jquery
     - core/jquery.once
     - core/drupal
+
+edit_plus:
+  version: VERSION
+  js:
+    js/edit-plus.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal

--- a/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.module
+++ b/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.module
@@ -146,6 +146,9 @@ function _burdastyle_thunder_admin_form_alter_helper(&$form, FormStateInterface 
   // Add BurdaStyle specific CSS for thunder_admin backend theme.
   $form['#attached']['library'][] = 'burdastyle_thunder_admin/form_styling';
 
+  // Add BurdaStyle specific JS for thunder_admin backend theme.
+  $form['#attached']['library'][] = 'burdastyle_thunder_admin/edit_plus';
+
   // Add CSS to fix broken travis tests with position fixed 'content-form-actions' region.
 	if (getenv('AH_SITE_ENVIRONMENT') == 'travis') {
 		$form['#attached']['library'][] = 'burdastyle_thunder_admin/travis_fix';

--- a/modules/burdastyle_thunder_admin/js/edit-plus.js
+++ b/modules/burdastyle_thunder_admin/js/edit-plus.js
@@ -1,0 +1,18 @@
+Drupal.behaviors.editPlus = {
+  formHasChanged: false,
+  attach(context) {
+    jQuery('input, select, textarea').on(
+        'change',
+        () => {
+          if (false === this.formHasChanged) {
+            jQuery('.tabs a[href$="/edit"], .tabs a[href$="/edit_plus"]').on('click', (e) => {
+              const answer = confirm('You have unsaved changes. Do you really want to leave this site?');
+              if (false === answer)
+                e.preventDefault();
+            });
+          }
+          this.formHasChanged = true;
+        }
+    );
+  },
+};


### PR DESCRIPTION
[INREL-4521](https://jira.burda.com/browse/INREL-4521)

Testing instructions:
* Edit an article
* make a change to the form
* switch between normal and edit_plus mode
* you should see an alert