### PR TITLE
INREL-4521 Warn editor when changing to editplus

### DIFF
--- a/modules/burdastyle_thunder_admin/js/edit-plus.js
+++ b/modules/burdastyle_thunder_admin/js/edit-plus.js
@@ -1,18 +1,39 @@
-Drupal.behaviors.editPlus = {
+/* eslint-disable no-alert */
+
+const handleEditedForms = {
   formHasChanged: false,
-  attach(context) {
-    jQuery('input, select, textarea').on(
-        'change',
-        () => {
-          if (false === this.formHasChanged) {
-            jQuery('.tabs a[href$="/edit"], .tabs a[href$="/edit_plus"]').on('click', (e) => {
-              const answer = confirm('You have unsaved changes. Do you really want to leave this site?');
-              if (false === answer)
-                e.preventDefault();
-            });
-          }
-          this.formHasChanged = true;
+  form: document.querySelector('#node-article-edit-form, #node-article-edit-plus-form'),
+  handleClick(e) {
+    const querySelector = '.tabs a[href$="/edit"], .tabs a[href$="/edit_plus"]';
+    const message = 'You have unsaved changes. Do you really want to leave this site?';
+    const clickedNavigation = e.target.matches(querySelector);
+
+    if (clickedNavigation && this.formHasChanged) {
+      const answer = window.confirm(message);
+      if (!answer) e.preventDefault();
+    }
+  },
+  handleFormChange() {
+    this.formHasChanged = true;
+  },
+  handleMutations(mutationList) {
+    const isChildList = !!mutationList.find(mutation => mutation.type === 'childList');
+    if (isChildList) {
+      Object.keys(CKEDITOR.instances).forEach((editor) => {
+        const instance = CKEDITOR.instances[editor];
+        if (!instance.listenerAdded) {
+          instance.on('change', e => this.handleFormChange(e));
+          instance.listenerAdded = true;
         }
-    );
+      });
+    }
+  },
+  init() {
+    const observer = new MutationObserver(this.handleMutations.bind(this));
+    observer.observe(this.form, { attributes: false, childList: true, subtree: true });
+    this.form.addEventListener('change', this.handleFormChange.bind(this));
+    document.body.addEventListener('click', this.handleClick.bind(this));
   },
 };
+
+document.addEventListener('DOMContentLoaded', handleEditedForms.init.bind(handleEditedForms));


### PR DESCRIPTION
## [INREL-4521](https://jira.burda.com/browse/INREL-4521) 
 - editor is warned when changing to edit plus when
 -- changes have been made to fields present on load
 -- changes have been made to fields within open/closed paragraphs
 -- changes have been made within CKEDITORs

## How to test:
 - Edit article
 - make changes to fields
 - change to editplus

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
