### PR TITLE
Trigger ecommerce paragraph autocomplete when a value is set by tipser tools INREL-4788

### DIFF
--- a/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.libraries.yml
+++ b/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.libraries.yml
@@ -26,3 +26,10 @@ edit_plus:
   dependencies:
     - core/jquery
     - core/drupal
+
+tipser:
+  version: VERSION
+  js:
+    js/tipser.js: {}
+  dependencies:
+    - core/drupal

--- a/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.module
+++ b/modules/burdastyle_thunder_admin/burdastyle_thunder_admin.module
@@ -148,6 +148,7 @@ function _burdastyle_thunder_admin_form_alter_helper(&$form, FormStateInterface 
 
   // Add BurdaStyle specific JS for thunder_admin backend theme.
   $form['#attached']['library'][] = 'burdastyle_thunder_admin/edit_plus';
+  $form['#attached']['library'][] = 'burdastyle_thunder_admin/tipser';
 
   // Add CSS to fix broken travis tests with position fixed 'content-form-actions' region.
 	if (getenv('AH_SITE_ENVIRONMENT') == 'travis') {

--- a/modules/burdastyle_thunder_admin/js/tipser.js
+++ b/modules/burdastyle_thunder_admin/js/tipser.js
@@ -1,0 +1,7 @@
+Drupal.behaviors.burdastyleThunderAdminTipser = {
+    attach: () => {
+        for (const input of document.querySelectorAll('.advertising-products-autocomplete')) {
+            input.addEventListener('change', (e) => { e.target.dispatchEvent(new Event('keydown')) });
+        }
+    }
+};


### PR DESCRIPTION
Trigger an keydown event when the value of the input changes, so the autocomplete is triggered.

See testing in instructions in comment of [INREL-4788](https://jira.burda.com/browse/INREL-4788)